### PR TITLE
fix: Firestore rules allow user profile

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,6 +7,37 @@ service cloud.firestore {
       return request.auth != null;
     }
 
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    function onlyKeys(allowed) {
+      return request.resource.data.keys().hasOnly(allowed);
+    }
+
+    // --- User profile ---
+    // Used by AuthProvider.upsertUserProfile + Header nickname display.
+    match /users/{uid} {
+      allow read: if isOwner(uid);
+
+      // allow create/update only by owner with whitelisted fields
+      allow create, update: if isOwner(uid)
+        && onlyKeys(['email','nickname','provider','createdAt','lastLogin','settings'])
+        && request.resource.data.nickname is string
+        && request.resource.data.nickname.size() >= 1
+        && request.resource.data.nickname.size() <= 32;
+
+      allow delete: if false;
+
+      // Optional: old client save location (if still used anywhere)
+      match /game/{docId} {
+        match /current {
+          allow read, create, update: if isOwner(uid);
+          allow delete: if false;
+        }
+      }
+    }
+
     // Static config: readable by anyone (or lock to signed-in if you prefer)
     match /configs/{docId} {
       allow read: if true;


### PR DESCRIPTION
Vercel(prod)에서 FirebaseError: Missing or insufficient permissions 발생 원인: firestore.rules가 기본 deny라서 /users/{uid} read/write가 차단됨.\n\n- /users/{uid} 본인 read 허용\n- AuthProvider.upsertUserProfile에서 쓰는 필드(email,nickname,provider,createdAt,lastLogin,settings) whitelist\n- (옵션) /users/{uid}/game/current도 owner read/write 허용\n\n적용 후 firebase deploy --only firestore:rules 필요.